### PR TITLE
Fix wrong base URL

### DIFF
--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,6 +1,6 @@
 import { getBlogPosts } from 'app/blog/utils'
 
-export const baseUrl = 'https://portfolio-blog-starter.vercel.app'
+export const baseUrl = 'https://hooniverse.me'
 
 export default async function sitemap() {
   let blogs = getBlogPosts().map((post) => ({


### PR DESCRIPTION
## Summary
- correct baseUrl used for metadata generation

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_683f9fc98edc8333a20e897767bfa663